### PR TITLE
Fix layout issue and update for XRT API change

### DIFF
--- a/src/literal.jl
+++ b/src/literal.jl
@@ -76,8 +76,9 @@ function Base.convert(::Type{LiteralProto}, a::Array{<:XLAScalar})
     # For performance on TPUs, we need to permute the dimensions to
     # have smaller dimensions be more major
     xlat = convert(XlaType, eltype(a))
-    perm = reverse(sortperm(collect(size(a)); rev=true))
+    perm = sortperm(collect(size(a)); rev=true)
     shape = Shape(xlat, size(a))
+    shape.layout.minor_to_major = perm .- 1
     lp = LiteralProto()
     lp.shape = shape
     assign_data!(lp, perm == [] ? vec(a) : vec(permutedims(a, perm)))

--- a/src/xrt.jl
+++ b/src/xrt.jl
@@ -7,7 +7,7 @@ mutable struct XRTCompilation
         buf = IOBuffer()
         writeproto(buf, comp)
         res = new(sess, comp.hlo_snapshot.hlo.hlo_module.program_shape,
-            run(sess, TensorFlow.Ops.xrt_compile(String(take!(buf)))))
+            run(sess, TensorFlow.Ops.xrt_compile(String(take!(buf))))[1])
         finalizer(close, res)
         res
     end


### PR DESCRIPTION
`XRTCompile` now returns the compilation handle _and_ the computation result shape, so add `[1]` to take only the handle.
The layouts assumed in creating an XLA literal and in building an XLA computation based on that literal were previously the opposite of each other; I don't know if I picked the right one for minimizing memory but they should definitely be the same.
The layout used in creating an XLA literal should be assigned to the LiteralProto's layout.minor_to_major attribute.